### PR TITLE
Introduce additonal unit tests for negotiators.

### DIFF
--- a/proactive/proactive_test.go
+++ b/proactive/proactive_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/freerware/negotiator/representation"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
 )
 
 type ProactiveTestSuite struct {
@@ -39,6 +41,8 @@ func (s *ProactiveTestSuite) SetupTest() {
 	s.sut = proactive.New(
 		proactive.Algorithm(s.chooser),
 		proactive.Representations(json.List),
+		proactive.Scope(tally.NoopScope),
+		proactive.Logger(zap.NewNop()),
 	)
 }
 

--- a/reactive/reactive_test.go
+++ b/reactive/reactive_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/freerware/negotiator/reactive"
 	"github.com/freerware/negotiator/representation"
 	"github.com/stretchr/testify/suite"
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
 )
 
 type ReactiveTestSuite struct {
@@ -28,6 +30,8 @@ func TestReactiveTestSuite(t *testing.T) {
 func (s *ReactiveTestSuite) SetupTest() {
 	s.sut = reactive.New(
 		reactive.Representation(json.List),
+		reactive.Scope(tally.NoopScope),
+		reactive.Logger(zap.NewNop()),
 	)
 }
 


### PR DESCRIPTION
## Overview

- Leverages `proactive.Logger(...)`, `reactive.Logger(...)`, `transparent.Logger(...)`, `proactive.Scope(...)`, `reactive.Scope(...)`, and `transparent.Scope(...)` in test suite setup.
- Introduces additional tests for `transparent` negotiator.
  - `TestTransparent_GuessSmallNegotiateHeader_ChoiceResponseToLarge(...)`
  - `TestTransparent_NegativeMaximumVariantListSize(...)`