### PR TITLE
Remove package 'negotiator' from 'make test' execution.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,7 @@ test: bins
 		github.com/freerware/negotiator/proactive \
 		github.com/freerware/negotiator/reactive \
 		github.com/freerware/negotiator/transparent \
-		github.com/freerware/negotiator/representation \
-		github.com/freerware/negotiator \
+		github.com/freerware/negotiator/representation
 
 	@echo done!
 


### PR DESCRIPTION
## OVERVIEW

- Removes the `negotiator` package from the `go test` command in the `test` target within `Makefile`.
  - This package doesn’t have any testable code, thus there are no unit tests for this package.