### PR TITLE
Freer/fix list representation

### DIFF
--- a/internal/representation/json/list.go
+++ b/internal/representation/json/list.go
@@ -25,6 +25,9 @@ import (
 func List(reps ...representation.Representation) representation.Representation {
 	list := _representation.List{}
 	list.SetContentType("application/json")
+	list.SetContentCharset("ascii")
+	list.SetContentEncoding([]string{"identity"})
+	list.SetContentLanguage("en-US")
 	list.SetRepresentations(reps...)
 	return list
 }

--- a/internal/representation/list.go
+++ b/internal/representation/list.go
@@ -50,6 +50,7 @@ func (l *List) SetRepresentations(reps ...rep.Representation) {
 			ContentLocation: (&loc).String(),
 			ContentCharset:  rep.ContentCharset(),
 			ContentFeatures: rep.ContentFeatures(),
+			SourceQuality:   rep.SourceQuality(),
 		})
 	}
 }

--- a/internal/representation/xml/list.go
+++ b/internal/representation/xml/list.go
@@ -25,6 +25,9 @@ import (
 func List(reps ...representation.Representation) representation.Representation {
 	list := _representation.List{}
 	list.SetContentType("application/xml")
+	list.SetContentCharset("ascii")
+	list.SetContentEncoding([]string{"identity"})
+	list.SetContentLanguage("en-US")
 	list.SetRepresentations(reps...)
 	return list
 }

--- a/internal/representation/yaml/list.go
+++ b/internal/representation/yaml/list.go
@@ -25,6 +25,9 @@ import (
 func List(reps ...representation.Representation) representation.Representation {
 	list := _representation.List{}
 	list.SetContentType("application/yaml")
+	list.SetContentCharset("ascii")
+	list.SetContentEncoding([]string{"identity"})
+	list.SetContentLanguage("en-US")
 	list.SetRepresentations(reps...)
 	return list
 }


### PR DESCRIPTION
**Description**

- Fixes the issue where `sourceQuality` was not being populated within the representation metadata in the list representations. [ #8 ]
- Fixes the issue where `Content-Encoding`, `Content-Language`, and `Content-Charset` were not being set for the list representations. [ #7 ]

**Rationale**

- Consumers benefit from knowing the source quality, as it provides a sense of "how well" the representation serves the intended purpose.
- Consumers benefit from understanding the encoding(s), language, and charset of the list representation in the response so that it can be interpreted correctly.

**Suggested Version**

`v0.1.1`

**Example Usage**

As these were bug fixes, there is no change to how the consumers leverage `negotiator`. Below is an example of the response with these bugs fixed. 
```
freer > curl -K get_account.curl 127.0.0.1:8000/accounts/ea8123f6-f42c-4c3a-9a19-987229b42780 | jq .
HTTP/1.1 406 Not Acceptable
Content-Charset: ascii
Content-Encoding: identity
Content-Language: en-US
Content-Length: 824
Content-Type: application/json
Date: Tue, 07 Apr 2020 05:11:15 GMT
{
  "representations": [
    {
      "contentType": "application/json",
      "contentLanguage": "en-US",
      "contentEncoding": [
        "identity"
      ],
      "contentLocation": "/accounts/ea8123f6-f42c-4c3a-9a19-987229b42780",
      "contentCharset": "ascii",
      "sourceQuality": 1.0
    },
    {
      "contentType": "application/yaml",
      "contentLanguage": "en-US",
      "contentEncoding": [
        "identity"
      ],
      "contentLocation": "/accounts/ea8123f6-f42c-4c3a-9a19-987229b42780",
      "contentCharset": "ascii",
      "sourceQuality": 0.8
    },
    {
      "contentType": "application/xml",
      "contentLanguage": "en-US",
      "contentEncoding": [
        "identity"
      ],
      "contentLocation": "/accounts/ea8123f6-f42c-4c3a-9a19-987229b42780",
      "contentCharset": "ascii",
      "sourceQuality": 0.8
    },
    {
      "contentType": "application/json",
      "contentLanguage": "en-US",
      "contentEncoding": [
        "gzip"
      ],
      "contentLocation": "/accounts/ea8123f6-f42c-4c3a-9a19-987229b42780",
      "contentCharset": "ascii",
      "sourceQuality": 0.9
    }
  ]
}
```
